### PR TITLE
Fixes for solution deploy

### DIFF
--- a/Byndyusoft.TemplateApi.csproj
+++ b/Byndyusoft.TemplateApi.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<PackageType>Template</PackageType>
-		<PackageVersion>1.0.4</PackageVersion>
+		<PackageVersion>1.0.5</PackageVersion>
 		<NoDefaultExcludes>true</NoDefaultExcludes>
 		<PackageId>Byndyusoft.Template</PackageId>
 		<Title>Byndyusoft.Template</Title>

--- a/templates/src/Api.Client/Api.Client.csproj
+++ b/templates/src/Api.Client/Api.Client.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
+    <IsPublishable>false</IsPublishable>
     <AssemblyName>Byndyusoft.Template.Api.Client</AssemblyName>
     <RootNamespace>Byndyusoft.Template.Api.Client</RootNamespace>
   </PropertyGroup>

--- a/templates/src/Api.Contracts/Api.Contracts.csproj
+++ b/templates/src/Api.Contracts/Api.Contracts.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
-    <IsPublishable>false</IsPublishable>
     <AssemblyName>Byndyusoft.Template.Api.Contracts</AssemblyName>
     <RootNamespace>Byndyusoft.Template.Api.Contracts</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/templates/src/Api.Contracts/Api.Contracts.csproj
+++ b/templates/src/Api.Contracts/Api.Contracts.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
+    <IsPublishable>false</IsPublishable>
     <AssemblyName>Byndyusoft.Template.Api.Contracts</AssemblyName>
     <RootNamespace>Byndyusoft.Template.Api.Contracts</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Current CI/CD infrastructure publishes whole solution via command `dotnet publish`. 
Unfortunately, clients and contracts target multiple frameworks and publish command returns error. That is why contracts and clients publishing was explicitly disabled.