### PR TITLE
Логи в json формате в проекте мигратора

### DIFF
--- a/templates/src/Migrator/Migrator.csproj
+++ b/templates/src/Migrator/Migrator.csproj
@@ -28,8 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentMigrator" Version="3.3.2" />
-    <PackageReference Include="FluentMigrator.Runner" Version="3.3.2" />
+    <PackageReference Include="Byndyusoft.Logging" Version="2.0.0" />
+    <PackageReference Include="FluentMigrator" Version="5.1.0" />
+    <PackageReference Include="FluentMigrator.Runner" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/templates/src/Migrator/Program.cs
+++ b/templates/src/Migrator/Program.cs
@@ -1,42 +1,57 @@
-﻿namespace Byndyusoft.Template.Migrator
+﻿namespace Byndyusoft.Template.Migrator;
+
+using System;
+using FluentMigrator.Runner;
+using Logging.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serilog;
+
+internal class Program
 {
-    using System;
-    using FluentMigrator.Runner;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-
-    internal class Program
+    private static int Main()
     {
-        private static void Main()
+        var serviceProvider = CreateServices();
+
+        using var scope = serviceProvider.CreateScope();
+
+        var runner = scope.ServiceProvider.GetRequiredService<IMigrationRunner>();
+
+        try
         {
-            var serviceProvider = CreateServices();
-
-            using var scope = serviceProvider.CreateScope();
-
-            var runner = scope.ServiceProvider.GetRequiredService<IMigrationRunner>();
-
             runner.MigrateUp();
         }
-
-        private static IServiceProvider CreateServices()
+        catch (Exception)
         {
-            var environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-
-            var configuration = new ConfigurationBuilder()
-                                .AddJsonFile("appsettings.json")
-                                .AddJsonFile($"appsettings.{environmentName}.json", true)
-                                .AddEnvironmentVariables()
-                                .Build();
-
-
-            return new ServiceCollection()
-                   .AddFluentMigratorCore()
-                   .ConfigureRunner(rb => rb
-                                          .AddPostgres()
-                                          .WithGlobalConnectionString(configuration.GetConnectionString("Main"))
-                                          .ScanIn(typeof(Program).Assembly).For.Migrations())
-                   .AddLogging(lb => lb.AddFluentMigratorConsole())
-                   .BuildServiceProvider(false);
+            return -1;
         }
+
+        return 0;
+    }
+
+    private static IServiceProvider CreateServices()
+    {
+        var environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        var configuration = new ConfigurationBuilder()
+                            .AddJsonFile("appsettings.json")
+                            .AddJsonFile($"appsettings.{environmentName}.json", true)
+                            .AddEnvironmentVariables()
+                            .Build();
+
+        Log.Logger = new LoggerConfiguration().UseDefaultEnrichSettings("Migrator")
+                                              .OverrideDefaultLoggers()
+                                              .UseConsoleWriterSettings()
+                                              .CreateLogger();
+
+        return new ServiceCollection()
+               .AddFluentMigratorCore()
+               .ConfigureRunner(rb => rb
+                                      .AddPostgres()
+                                      .WithGlobalConnectionString(configuration.GetConnectionString("Main"))
+                                      .ScanIn(typeof(Program).Assembly).For.Migrations())
+               .AddLogging(lb => lb.ClearProviders().AddSerilog(Log.Logger, dispose: true))
+               .BuildServiceProvider(false);
     }
 }


### PR DESCRIPTION
Добавил пакет Byndyusoft.Logging в мигратор и заменил логгер из FluentMigrator на Serilog.
Код выхода из приложения был введен в методе main, т.к. если приложение завершается через throw, то в консоль попадают записи стандартного логгера и, по сути, дублируются.